### PR TITLE
Add TableTraits.jl integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,5 @@
 julia 0.7-
 Indexing
+IteratorInterfaceExtensions
+TableTraits
+TableTraitsUtils

--- a/src/MinimumViableTables.jl
+++ b/src/MinimumViableTables.jl
@@ -11,6 +11,7 @@ import LinearAlgebra: cross, ×
 using Unicode
 using Indexing
 #using DataStreams
+import IteratorInterfaceExtensions, TableTraits, TableTraitsUtils
 
 export colnames, columns, accelerators, project, Project, accelerate, rename, Rename
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -28,6 +28,20 @@ function Table{names}(nt::NamedTuple{names2, <:Tuple{Vararg{AbstractVector}}}, i
     end
 end
 
+# TableTraits.jl integration
+function Table(source)
+    iit = TableTraits.isiterabletable(source)
+    if iit===true
+        cols, names = TableTraitsUtils.create_columns_from_iterabletable(source, na_representation=:datavalue)
+    elseif iit===missing
+        error("Not yet implemented.")
+    else
+        error("Argument is not a table.")
+    end
+
+    return Table(NamedTuple{tuple(names...),Tuple{typeof.(cols)...}}(cols))
+end
+
 # Helpers to get the data directly from the Table struct
 accelerators(::AbstractVector{<:NamedTuple}) = ()
 accelerators(t::Table) = Core.getfield(t, :accelerators)


### PR DESCRIPTION
This gives you full integration with the Queryverse.jl. So you get file IO (CSV, Feather, Excel, SAS, SPSS, STATA, Parquet), plotting (VegaLite.jl, StatsPlots.jl, Gadfly.jl, DataVoyager.jl), conversion to and from other tables (pretty much all table types, DataFrames, IndexedTables, TimeSeries, Temporal, Pandas) and it works with Query.jl, and I probably forgot something ;)

In case you are worried about taking on additional dependencies, here is the landscape on that: IteratorInterfaceExtensions.jl and TableTraits.jl are super stable. I haven't changed anything (apart from the julia 0.7 update) about these in about 1.5 years, and I plan to make zero changes going forward. They are also super minimal (take a look), so I think there is no risk in taking a dependency on these (and I think I have a track record at this point for not breaking stuff, ask e.g. Chris Rackauckas what his experience has been with taking the same dependency for his ecosystem). TableTraitsUtils.jl is getting changes as I improve the implementation there, but I am also not breaking packages that use it. It is also not really necessary to play in the Queryverse, it really is just a shortcut to make it a bit easier to implement the interface. So if this dependency was not welcome, one could remove it down the road (but then would need a bit more code here in the repo).

The whole TableTraits.jl story is documented [here](http://www.david-anthoff.com/jl4ds/stable/tabletraits.html). There is one twist, and that is that ``isiterabletable`` can now return ``missing``. The code in this PR doesn't handle that yet. At this point there are no sources that lead to this, so it shouldn't be an issue, and I would follow up and fix this later.

Should also say that I like everything I see here A LOT! I think there is also room for a much deeper integration between Query.jl and this stuff here, with a custom Query.jl backend that makes use of the acceleration stuff you have. But we could try to figure that out in a second step.